### PR TITLE
Specify version of the remote theme to avoid issues

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: Robust and Secure Distributed Computing
 tagline: Research Unit in Fondazione Bruno Kessler (FBK)
 logo: /assets/images/logos/RiSING_symbol.png
-remote_theme: chrisrhymes/bulma-clean-theme
+remote_theme: chrisrhymes/bulma-clean-theme@v0.13.3
 markdown: kramdown
 repository: risingfbk/risingfbk.github.io
 url: "https://rising.fbk.eu"


### PR DESCRIPTION
As the remote theme has been updated, it now raises compilation errors.
Therefore, we should specify the version of the remote theme that needs to be used, so as to avoid issues.