### PR TITLE
Update Jekyll workflow due to deprecation notice

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -49,7 +49,7 @@ jobs:
           JEKYLL_ENV: production
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
 
   # Deployment job
   deploy:
@@ -61,4 +61,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
The Jekyll workflow has been failing since yesterday due to the deprecation of v3 of the `upload-artifact` action (see [GitHub Changelog](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)), which was used in v2 of the `upload-pages-artifact` action.

This commit updates the action versions to resolve the issue:
- `upload-pages-artifact`: from v2 to v3
- `deploy-pages`: from v2 to v4 (to properly handle the new version of `upload-pages-artifact`)